### PR TITLE
78 add reference to the milan readme installation guide and test results to the top level readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,23 @@
+# PipeWire Milan
+This mirror is dedicated to the integration of the AVB Milan specification into pipewire. For more information please see the [README](https://github.com/kebag-logic/pipewire/blob/milan-avb-dev/src/modules/module-avb/README.md) in the module-avb.
+
+## Installation guide
+
+**Note**: Please follow step 1 to step 3 to completely set up your system from scratch.
+
+1. For setting up a dedicated Arch Linux machine, follow the steps in the [Arch Linux Guide](https://github.com/kebag-logic/pipewire/blob/milan-avb-dev/src/modules/module-avb/doc/INSTALL.md#automatic-installation)
+2. For setting up pipewire on your Arch Linux machine you need to install
+
+    1. LinuxPTP: [LinuxPTP Guide](https://github.com/kebag-logic/pipewire/blob/milan-avb-dev/src/modules/module-avb/doc/INSTALL.md#automatic-installation)
+    2. PipeWire from the `milan-avb-dev` branch: [PipeWire Installation Guide](https://github.com/kebag-logic/pipewire/blob/milan-avb-dev/src/modules/module-avb/doc/INSTALL.md#automatic-installation)
+
+3. For running PipeWire with the Milan implementation, follow the steps in the [Pipewire System Guide](https://github.com/kebag-logic/pipewire/blob/milan-avb-dev/src/modules/module-avb/doc/INSTALL.md#automatic-installation)
+
+# Test Results
+The PipeWire Milan implementation follows a very loose behavior test. 
+
+Current Test Results can be found in the [Test Results](https://github.com/kebag-logic/pipewire/blob/milan-avb-dev/src/modules/module-avb/doc/TESTS.md) section.
+
 # PipeWire
 
 [PipeWire](https://pipewire.org) is a server and user space API to

--- a/src/modules/module-avb/README.md
+++ b/src/modules/module-avb/README.md
@@ -26,7 +26,7 @@ Installation instructions are available here:
 
 We welcome contributions and collaboration from the community to help move
 the project forward
-See the [Issues list](https://github.com/kebag-logics/pipewire/issues) if you'd
+See the [Issues list](https://github.com/kebag-logic/pipewire/issues) if you'd
 like to contribute.
 
 ## Current Test Results

--- a/src/modules/module-avb/doc/INSTALL.md
+++ b/src/modules/module-avb/doc/INSTALL.md
@@ -203,7 +203,7 @@ Retrieve the source using git in your home Folder (~).:
 
 ```bash
 git clone --single-branch --branch milan-avb-dev \
-   https://github.com/kebag-logics/pipewire.git ~/pipewire
+   https://github.com/kebag-logic/pipewire.git ~/pipewire
 ```
 
 ## Prepare the system to Run PipeWire


### PR DESCRIPTION
This PR updates the module Readme and Installation guide to the github.com/kebag-logic/ links. 